### PR TITLE
Fix typo in getting started doc

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -18,7 +18,7 @@ with the following attributes:
     The *name* is simply a standardized format of the name as an attribute to
     help identify which function is being represented [#footnote_name]_ .
 
-``ndim``
+``.ndim``
     Number of dimensions. This is the dimensionality (i.e. length) of the input
     vector X of which the objective is evaluated.
 


### PR DESCRIPTION
The `.ndim` attribute did not have a leading period like the other attributes in the documentation did.

Furthermore, at first I found the wording somewhat confusing for the description of `ndim`. I think it would be helpful to state somewhere in the getting started documentation the more formal mathematical definition of the MF functions. Something like: "Each mf2 function maps a real valued input vector to a real valued scalar" or something similar. 
However, perhaps I'm just being slow.