### PR TITLE
specified version as dynamic from __init__.py

### DIFF
--- a/mf2/__init__.py
+++ b/mf2/__init__.py
@@ -5,8 +5,6 @@ mf2
 
 A collection of analytical functions with 2 or more available fidelities.
 """
-import pkg_resources
-
 from .multi_fidelity_function import MultiFidelityFunction, invert
 from .borehole import borehole
 from .currin import currin
@@ -24,7 +22,7 @@ import mf2.adjustable
 
 __author__ = 'Sander van Rijn'
 __email__ = 's.j.van.rijn@liacs.leidenuniv.nl'
-__version__ = pkg_resources.get_distribution('mf2').version
+__version__ = '2022.06.0'
 
 
 bi_fidelity_functions = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mf2"
-version = "2022.6.0"
+dynamic = ["version"]
 description = "A collection of analytical benchmark functions in multiple fidelities"
 readme = "README.md"
 authors = [
@@ -51,3 +51,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["mf2"]
+
+[tool.setuptools.dynamic]
+version = {attr = "mf2.__version__"}


### PR DESCRIPTION
- Deprecate `pkg_resources`
- specify __version__ in `mf2/__init__.py` instead of `pyproject.toml`
- dynamically load version in `pyproject.toml` from `mf2/__init__.py`